### PR TITLE
should publish from alpha releases instead from beta releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ web
 .composer
 .ssh
 .DS_Store
-
+vendor

--- a/satis.json
+++ b/satis.json
@@ -9,7 +9,7 @@
     "dxpr/dxpr_builder": "*",
     "dxpr/dxpr_builder_e": "*"
   },
-  "minimum-stability": "beta",
+  "minimum-stability": "alpha",
   "archive": {
     "directory": "dist",
     "format": "zip",


### PR DESCRIPTION
there is a related bug from satis (https://github.com/composer/satis/issues/655), hopefully it will be fixed soon to build and publish the new releases

```
  - Downloading dxpr/dxpr_builder (1.5.0-alpha1)

In Filesystem.php line 352:
                                                                                                                                        
  [ErrorException]                                                                                                                      
  copy(/tmp/composer_archiver60ec7d6bc6f25/619ff4c467c4b6cb48b341a8ceed21d944c4599d): Failed to open stream: No such file or directory  
                                                                                                                                        

Exception trace:
  at /satis/vendor/composer/composer/src/Composer/Util/Filesystem.php:352
 Composer\Util\ErrorHandler::handle() at n/a:n/a
 copy() at /satis/vendor/composer/composer/src/Composer/Util/Filesystem.php:352
 Composer\Util\Filesystem->copy() at /satis/vendor/composer/composer/src/Composer/Util/Filesystem.php:332
 Composer\Util\Filesystem->copyThenRemove() at /satis/vendor/composer/composer/src/Composer/Util/Filesystem.php:412
 Composer\Util\Filesystem->rename() at /satis/src/Builder/ArchiveBuilder.php:202
 Composer\Satis\Builder\ArchiveBuilder->archive() at /satis/src/Builder/ArchiveBuilder.php:111
 Composer\Satis\Builder\ArchiveBuilder->dump() at /satis/src/Console/Command/BuildCommand.php:197
 Composer\Satis\Console\Command\BuildCommand->execute() at /satis/vendor/symfony/console/Command/Command.php:299
 Symfony\Component\Console\Command\Command->run() at /satis/vendor/symfony/console/Application.php:978
 Symfony\Component\Console\Application->doRunCommand() at /satis/vendor/symfony/console/Application.php:295
 Symfony\Component\Console\Application->doRun() at /satis/src/Console/Application.php:49
 Composer\Satis\Console\Application->doRun() at /satis/vendor/symfony/console/Application.php:167
 Symfony\Component\Console\Application->run() at /satis/bin/satis:60

build [--repository-url [REPOSITORY-URL]] [--repository-strict] [--no-html-output] [--skip-errors] [--stats] [--] [<file> [<output-dir> [<packages>...]]]
```