### PR TITLE
@ #9 | should not use the satis:latest docker image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - ./web:/src/web
 
   build:
-    image: ${SATIS_IMAGE:-composer/satis:latest}
+    image: ${SATIS_IMAGE:-hoatle/satis:4d42fc6}
     working_dir: /src
     command: build satis.json web/8 --no-interaction -vv
     tty: true


### PR DESCRIPTION
connect #9 

you can retag the build docker image to use the dxpr account instead.