### PR TITLE
should use ubuntu 20.04 instead of the deprecated one

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ env:
 jobs:
 
   build-publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 


### PR DESCRIPTION
this should fix the failed github action job